### PR TITLE
perftools.rb fixes for GNU patch

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -27,6 +27,7 @@ perftools = File.basename('google-perftools-1.4.tar.gz')
 dir = File.basename(perftools, '.tar.gz')
 
 puts "(I'm about to compile google-perftools.. this will definitely take a while)"
+ENV["PATCH_GET"] = '0'
 
 Dir.chdir('src') do
   FileUtils.rm_rf(dir) if File.exists?(dir)


### PR DESCRIPTION
The patch command, when using GNU patch, will attempt to prompt the user to check files out of perforce (this feature doesn't exist in BSD patch and thus isn't a problem).

This is a problem in the 0.5.0 release in rubygems, where the patching in extconf.rb will fail on any modern GNU patch.

Issuing -g0 will quell this prompting and patching will go smoothly.

My heuristic is probably crap, but it works on OS X (with GNU patch via macports) and FreeBSD.
