### PR TITLE
perftools 1.6 cannot compile with gcc 4.6.0

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -51,7 +51,8 @@ Dir.chdir('src') do
       ['perftools-osx', RUBY_PLATFORM =~ /darwin/],
       ['perftools-debug', true],
       ['perftools-objects', true],
-      ['perftools-frames', true]
+      ['perftools-frames', true],
+      ['perftools-stddef', true]
     ].each do |patch, apply|
       if apply
         sys("patch -p1 < ../../../patches/#{patch}.patch")

--- a/patches/perftools-stddef.patch
+++ b/patches/perftools-stddef.patch
@@ -1,0 +1,34 @@
+Only in ./: perftools-stddef.patch
+diff -ru .//src/base/vdso_support.h ../google-perftools-1.6-patched/src/base/vdso_support.h
+--- .//src/base/vdso_support.h	2010-08-03 03:32:20.000000000 +0800
++++ ../google-perftools-1.6-patched/src/base/vdso_support.h	2011-06-16 14:33:10.000000000 +0800
+@@ -38,6 +38,7 @@
+ #define HAVE_VDSO_SUPPORT 1
+ 
+ #include <stdlib.h>     // for NULL
++#include <stddef.h>
+ #include <link.h>  // for ElfW
+ #include "base/basictypes.h"
+ 
+diff -ru .//src/symbolize.h ../google-perftools-1.6-patched/src/symbolize.h
+--- .//src/symbolize.h	2009-11-11 03:59:46.000000000 +0800
++++ ../google-perftools-1.6-patched/src/symbolize.h	2011-06-16 14:32:55.000000000 +0800
+@@ -38,6 +38,7 @@
+ #include <stdint.h>  // for uintptr_t
+ #endif
+ #include <map>
++#include <stddef.h>
+ 
+ using std::map;
+ 
+diff -ru .//src/system-alloc.h ../google-perftools-1.6-patched/src/system-alloc.h
+--- .//src/system-alloc.h	2010-04-01 07:50:18.000000000 +0800
++++ ../google-perftools-1.6-patched/src/system-alloc.h	2011-06-16 14:32:38.000000000 +0800
+@@ -38,6 +38,7 @@
+ 
+ #include <config.h>
+ #include "internal_logging.h"
++#include <stddef.h>
+ 
+ // REQUIRES: "alignment" is a power of two or "0" to indicate default alignment
+ //


### PR DESCRIPTION
I'm using archlinux, gcc version 4.6, rvm 1.6.13, ruby 1.9.2-p180. I get some compile error when install latest perftools.rb, and it turns out a 1.6 bug: http://code.google.com/p/chromium/issues/detail?id=80071

I'm not sure whether this problem exists in other gcc versions, and my patch will affect perftools.rb on all gcc versions, so please be careful if you want to merge :)
