### PR TITLE
Fix "undefined symbol `ruby_current_thread'" when compiling against Ruby 1.9.3-p0

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -90,7 +90,10 @@ when /darwin/, /linux/, /freebsd/
 end
 
 if RUBY_VERSION >= "1.9"
+  major, minor, patch = RUBY_VERSION.split('.').map!(&:to_i)
+
   add_define 'RUBY19'
+  add_define 'RUBY193' if patch >= 3
 
   hdrs = proc {
     have_header("method.h") # exists on 1.9.2

--- a/ext/perftools.c
+++ b/ext/perftools.c
@@ -123,6 +123,10 @@ static VALUE Isend;
   #include <vm_core.h>
   #include <iseq.h>
 
+  #ifdef RUBY193
+    #define ruby_current_thread ((rb_thread_t *)RTYPEDDATA_DATA(rb_thread_current()))
+  #endif
+
   int
   rb_stack_trace(void** result, int max_depth)
   {


### PR DESCRIPTION
Hi, I've cargo-culted the fix from ruby-debug-base19 v0.11.26 and tested against 1.9.3-p0.

Can you please apply? :-)

Thanks!

~Marcello
