### PR TITLE
Update README: Ubuntu/Debian prerequisite packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The sampling interval of the profiler can be adjusted to collect more
   You'll also need graphviz to generate call graphs using dot:
 
     sudo brew    install graphviz ghostscript # osx
-    sudo apt-get install graphviz ps2pdf      # debian/ubuntu
+    sudo apt-get install graphviz ghostscript # debian/ubuntu
 
   If graphviz fails to build on OSX Lion, you may need to recompile libgd, [see here](https://github.com/mxcl/homebrew/issues/6645#issuecomment-1806807)
 


### PR DESCRIPTION
There is no such "ps2pdf" package, "ghostscript" is the one you need to install.
