### PR TITLE
Fix the object allocation profile mode on Ruby 2.x

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -98,6 +98,10 @@ end
 if RUBY_VERSION >= "1.9"
   add_define 'RUBY19'
 
+  if RUBY_VERSION >= "2.0"
+    add_define 'HAVE_RB_NEWOBJ_OF'
+  end
+
   hdrs = proc {
     have_header("method.h") # exists on 1.9.2
     have_header("vm_core.h") and

--- a/ext/perftools.c
+++ b/ext/perftools.c
@@ -38,6 +38,12 @@ static VALUE Isend;
     result[depth++] = (void*) (method == ID_ALLOCATOR ? Iallocate : method); \
   }
 
+#ifdef HAVE_RB_NEWOBJ_OF
+  #define NEWOBJ_FUNC rb_newobj_of
+#else
+  #define NEWOBJ_FUNC rb_newobj
+#endif
+
 #ifdef RUBY18
   #include <env.h>
   #include <node.h>
@@ -492,11 +498,11 @@ objprofiler_setup()
   sigemptyset(&sig.sa_mask);
   sigaction(SIGTRAP, &sig, NULL);
 
-  unprotect_page((char*)rb_newobj);
+  unprotect_page((char*)NEWOBJ_FUNC);
 
   for (i=0; i<NUM_ORIG_BYTES; i++) {
-    orig_bytes[i].location = (char *)rb_newobj + i;
-    orig_bytes[i].value    = ((unsigned char*)rb_newobj)[i];
+    orig_bytes[i].location = (char *)NEWOBJ_FUNC + i;
+    orig_bytes[i].value    = ((unsigned char*)NEWOBJ_FUNC)[i];
     orig_bytes[i].location[0] = '\xCC';
   }
 


### PR DESCRIPTION
The object allocation profiler currently works by patching the
rb_newobj function in Ruby. This function is no longer directly used
in Ruby 2.x - rb_newobj_of is used instead.

This change patches either rb_newobj or rb_newobj_of, depending on
whether the targeted Ruby version has rb_newobj_of available.
