### PR TITLE
Better Ruby 2.x Support with `debase-ruby_core_source`

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -10,7 +10,7 @@ end
 
 require 'mkmf'
 require 'fileutils'
-if RUBY_VERSION > "2.1"
+if RUBY_VERSION > "1.9"
   begin
     require 'debase/ruby_core_source'
   rescue LoadError
@@ -22,7 +22,7 @@ if RUBY_VERSION > "2.1"
     Gem::Specification.find_by_name('debase-ruby_core_source').activate
     require 'debase/ruby_core_source'
   end
-elsif RUBY_VERSION >= "1.9"
+else
   begin
     require "debugger/ruby_core_source"
   rescue LoadError

--- a/perftools.rb.gemspec
+++ b/perftools.rb.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'perftools.rb'
-  s.version = '2.0.2'
+  s.version = '2.0.3'
   s.rubyforge_project = 'perftools-rb'
   s.summary = 'gperftools for ruby code'
   s.description = 'A sampling profiler for ruby code based on patches to gperftools'


### PR DESCRIPTION
While `debugger-ruby_core_source` supports some versions of Ruby 2.x, it does not support most of the latest patch levels. I think it is better to use `debase-ruby_core_source` for all Ruby 2.x since it has more comprehensive and recent coverage of recent sources.