### PR TITLE
fix Ruby 1.9.3 compatibility

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -10,7 +10,7 @@ end
 
 require 'mkmf'
 require 'fileutils'
-if RUBY_VERSION > "1.9"
+if RUBY_VERSION > "1.9.3"
   begin
     require 'debase/ruby_core_source'
   rescue LoadError

--- a/perftools.rb.gemspec
+++ b/perftools.rb.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'perftools.rb'
-  s.version = '2.0.3'
+  s.version = '2.0.4'
   s.rubyforge_project = 'perftools-rb'
   s.summary = 'gperftools for ruby code'
   s.description = 'A sampling profiler for ruby code based on patches to gperftools'


### PR DESCRIPTION
Really sorry about this, my previous PR actually broke compatibility with Ruby 1.9.3 because the RUBY_VERSION assertion also asserts for patch versions, which means Ruby 1.9.1, 1.9.2, 1.9.3 will try to use `debase/ruby_core_source`, which is incompatible.

Really sorry about this...