### PR TITLE
`vm_core.h` may be a prereq for `iseq.h`

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -116,7 +116,7 @@ if RUBY_VERSION >= "1.9"
   hdrs = proc {
     have_header("method.h") # exists on 1.9.2
     have_header("vm_core.h") and
-    have_header("iseq.h") and
+    (have_header("iseq.h") or have_header("iseq.h", ["vm_core.h"])) and
     have_header("insns.inc") and
     have_header("insns_info.inc")
   }


### PR DESCRIPTION
@tmm1, @emilpetkov - I think this is a fix for https://github.com/tmm1/perftools.rb/issues/77 . If it isn't, at least it fixes my problem. In my case the system is OSX 10.11.5 (El Cap) and MRI 2.1.2. Looking at my `mkmf.log`, the header detection failed because of some type decls done in `vm_core.h`, but the test C file doesn't include that. Outside the header detection, `iseq.h` [is only referenced here](https://github.com/tmm1/perftools.rb/blob/e1beb6b/ext/perftools.c#L135-L136).